### PR TITLE
docs: add npm to ubuntu installation instructions

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -18,7 +18,7 @@ Otherwise there is also an [installer](https://nodejs.org/en/download/).
 ### Ubuntu
 
 ```
-sudo apt install nodejs
+sudo apt install nodejs npm
 ```
 
 ### Windows


### PR DESCRIPTION
Npm package is missing in the ubuntu installation instruction.

Best regards,